### PR TITLE
TST: test on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         - '3.8'
         - '3.9'
         - '3.10'
-        # - '3.11'
+        - '3.11'
         include:
         - os: macos-latest
-          python-version: '3.10'
+          python-version: '3.11'
         - os: windows-latest
-          python-version: '3.10'
+          python-version: '3.11'
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +57,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This won't ship until scikit-image has wheels for Python 3.11