### PR TITLE
BLD: migrate to Cython 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
 	"setuptools>=61.2",
-	"Cython>=0.29.22",
+	"Cython>=3.0.0b1,<3.1",
 	"oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
                 define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
             ),
         ],
-        compiler_directives={"language_level": 3},
-        annotate=True,
+        # annotate=True, # uncomment to produce html reports
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
                 "lick._vendor.vectorplot.core",
                 ["lick/_vendor/vectorplot/core.pyx"],
                 include_dirs=[numpy.get_include()],
+                define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
             ),
         ],
         compiler_directives={"language_level": 3},


### PR DESCRIPTION
Supposedly Cython 3.0 will not generate code using deprecated numpy API anymore, so let's formally forbid it. This patch should fail CI at first sinc Cython 3.0 is still in beta.