### PR TITLE
MNT: noop refactor in setup.py to prepare transition out of Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@ define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
 if sys.version_info >= (3, 9):
     # keep in sync with runtime requirements (pyproject.toml)
     define_macros.append(("NPY_TARGET_VERSION", "NPY_1_18_API_VERSION"))
+else:
+    pass
 
 setup(
     ext_modules=cythonize(


### PR DESCRIPTION
the reason for adding these lines is that it'll enable pyupgrade (ruff) to auto clean up this conditional when Python 3.8 is dropped