### PR TITLE
BLD: add support for numpy>=2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=61.2",
     "Cython>=3.0",
-    "numpy>=1.25, <2.0",
+    "numpy>=2.0.0rc1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -23,8 +23,7 @@ requires-python = ">=3.9"
 dependencies = [
     "matplotlib>=3.4.0",
     # keep in sync with NPY_TARGET_VERSION (setup.py)
-    # https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628865694
-    "numpy>=1.19.3,<2.0",
+    "numpy>=1.19.3, <3",
     "scikit-image>=0.18.1",
     "scipy>=1.5.4",
     "packaging>=20.9",


### PR DESCRIPTION
Numpy 2.0 isn't out yet but is expected to land in a couple month. I had a couple minutes on my hand so I prepared the patch now, but I'll leave it as a draft until the release candidate is actually available.