### PR TITLE
DEP: drop scikit-image as a dependency

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -36,7 +36,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install setuptools wheel
         python -m pip install --pre --only-binary ":all:" \
-          numpy matplotlib scipy scikit-image \
+          numpy matplotlib scipy \
           --extra-index \
           https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "matplotlib>=3.4.0",
     # keep in sync with NPY_TARGET_VERSION (setup.py)
     "numpy>=1.19.3, <3",
-    "scikit-image>=0.18.1",
     "scipy>=1.5.4",
     "packaging>=20.9",
 ]


### PR DESCRIPTION
Progressicely replacing `scikit_image.exposure.equalize_hist` with the equivalent pure numpy code.