### PR TITLE
TYP: require matplotlib >= 3.8.1 for typechecking

### DIFF
--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,1 +1,2 @@
 mypy==1.9.0
+matplotlib>=3.8.1


### PR DESCRIPTION
follow up to #109