### PR TITLE
TST: add CPython 3.13 to regular CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,18 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
+        venv-loc: [bin]
         include:
         - os: macos-latest
-          python-version: '3.12'
+          python-version: '3.13'
+          venv-loc: bin
         - os: windows-latest
-          python-version: '3.12'
+          python-version: '3.13'
+          venv-loc: Scripts
         - os: ubuntu-20.04
           python-version: '3.9'
+          venv-loc: bin
           install-args: --resolution=lowest-direct
 
     runs-on: ${{ matrix.os }}
@@ -58,7 +63,12 @@ jobs:
     - run: uv pip list
 
     - name: Test
-      run: uv run pytest --color=yes -ra
+      shell: bash
+      # in principle this could be done with uv run pytest, but resolution
+      # appears buggy as of uv 0.4.20 and causes crashes
+      run: |
+        source .venv/${{matrix.venv-loc}}/activate
+        pytest --color=yes -ra
 
   image-tests:
     name: Image tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import matplotlib as mpl
+
+# see https://github.com/matplotlib/matplotlib/issues/28957
+mpl.use("Agg")


### PR DESCRIPTION
blocked by uv (wait for a version that knows how to install 3.13 stable)