### PR TITLE
TST: add CPython 3.13 to regular test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,15 +51,15 @@ jobs:
 
     - name: Build
       run: |
-        uv venv --python ${{ matrix.python-version }}
-        uv pip install . --no-deps
-        uv pip compile pyproject.toml --no-build ${{ matrix.install-args }} | uv pip install -r -
-        uv pip install --requirement requirements/tests.txt
+        uv venv --verbose --python ${{ matrix.python-version }}
+        uv pip install --verbose . --no-deps
+        uv pip compile --verbose pyproject.toml --no-build ${{ matrix.install-args }} | uv pip install -r -
+        uv pip install --verbose --requirement requirements/tests.txt
 
     - run: uv pip list
 
     - name: Test
-      run: uv run pytest --color=yes -ra
+      run: uv --verbose run pytest --color=yes -ra
 
   image-tests:
     name: Image tests
@@ -77,14 +77,14 @@ jobs:
     - name: Build
       run: |
         uv venv --python 3.13
-        uv sync
-        uv pip install --requirement requirements/tests.txt
+        uv sync --verbose
+        uv pip install --verbose --requirement requirements/tests.txt
 
     - run: uv pip list
 
     - name: Run Image Tests
       run: |
-        uv run pytest --color=yes --mpl -m mpl_image_compare \
+        uv run --verbose pytest --color=yes --mpl -m mpl_image_compare \
                --mpl-generate-summary=html \
                --mpl-results-path=lick_pytest_mpl_results \
                --mpl-baseline-path=tests/pytest_mpl_baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,7 @@ jobs:
     - name: Build
       run: |
         uv venv --python 3.13
-        uv sync --verbose
-        uv pip install --verbose --requirement requirements/tests.txt
+        uv pip install --verbose . -r requirements/tests.txt
 
     - run: uv pip list
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,6 @@ jobs:
     - name: Checkout Source
       uses: actions/checkout@v4
     - uses: astral-sh/setup-uv@v3
-      with:
-        enable-cache: true
-        cache-dependency-glob: |
-          **/requirements/tests.txt
-          **/pyproject.toml
 
     - name: Build
       run: |
@@ -68,11 +63,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: astral-sh/setup-uv@v3
-      with:
-        enable-cache: true
-        cache-dependency-glob: |
-          **/requirements/tests.txt
-          **/pyproject.toml
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,12 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
         include:
         - os: macos-latest
-          python-version: '3.12'
+          python-version: '3.13'
         - os: windows-latest
-          python-version: '3.12'
+          python-version: '3.13'
         - os: ubuntu-20.04
           python-version: '3.9'
           install-args: --resolution=lowest-direct
@@ -75,7 +76,7 @@ jobs:
 
     - name: Build
       run: |
-        uv venv --python 3.12
+        uv venv --python 3.13
         uv sync
         uv pip install --requirement requirements/tests.txt
 


### PR DESCRIPTION
Alternative to #138 with the minimal patch + debug outputs in uv so I can report the issues I saw yesterday.