### PR TITLE
PERF: shave 5% overhead from exception checking

### DIFF
--- a/src/lick/_vendor/vectorplot/core.pyx
+++ b/src/lick/_vendor/vectorplot/core.pyx
@@ -13,7 +13,7 @@ cdef fused real:
 
 @cython.cdivision
 cdef inline void _advance(real vx, real vy,
-        int* x, int* y, real*fx, real*fy, int w, int h):
+        int* x, int* y, real*fx, real*fy, int w, int h) noexcept:
     """Move to the next pixel in the vector direction.
 
     This function updates x, y, fx, and fy in place.


### PR DESCRIPTION
Explanation: this removes the part of the generated C function that checks on exception status every time it's called.

I measured a 5% gain on the following benchmark script:
```python
from lick import lick
import numpy as np
from time import monotonic_ns
from tqdm import tqdm
x = y = np.linspace(0, np.pi, 1024)
XX, YY = np.meshgrid(x, y, indexing="xy")
V1 = np.cos(XX).astype("float32")
V2 = np.sin(YY).astype("float32")


NIT = 100
tstart = monotonic_ns()
for _ in tqdm(range(NIT)):
    lick(V1, V2, niter_lic=1)
tstop = monotonic_ns()
tspan_ms = (tstop-tstart)/1e6

print(f"{NIT} iterations in {tspan_ms:.0f} ms ({tspan_ms/NIT:.0f} ms/it)")
```
